### PR TITLE
fix(kick): support sessions for logged out users

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -68,7 +68,7 @@ declare global {
 	interface Session {
 		eventBus: Publisher
 		networkInterface: NetworkInterface
-		meData: MeData
+		meData?: MeData
 		channelData: ChannelData
 		usersManager: UsersManager
 		userInterface?: AbstractUserInterface

--- a/src/Extensions/SevenTV/index.ts
+++ b/src/Extensions/SevenTV/index.ts
@@ -399,7 +399,7 @@ export default class SevenTVExtension extends Extension {
 			)
 
 		const { channelId, userId: channelUserId } = session.channelData
-		const platformMeUserId = session.meData.userId
+		const platformMeUserId = session.meData?.userId
 
 		this.registerEmoteProvider(session)
 
@@ -422,7 +422,8 @@ export default class SevenTVExtension extends Extension {
 				})
 		)
 
-		if (!this.cachedStvMeUser) {
+		// Logged out users have no platform user id, so there is no personal 7TV data to fetch.
+		if (!this.cachedStvMeUser && platformMeUserId) {
 			promises.push(
 				getUserCosmeticDataByConnection(platformId, platformMeUserId)
 					.then(res => res?.userByConnection ?? { id: STV_ID_NULL })

--- a/src/Sites/Kick/KickNetworkInterface.ts
+++ b/src/Sites/Kick/KickNetworkInterface.ts
@@ -189,10 +189,12 @@ export default class KickNetworkInterface implements NetworkInterface {
 		// this.session.meData.channelId = '' + responseChannelData.id
 
 		const userData = await RESTFromMainService.get('https://kick.com/api/v1/user').catch(() => {})
-		if (!userData) throw new Error('Failed to fetch user data')
 
-		if (!userData.streamer_channel)
-			throw new Error('Invalid user data, missing property "streamer_channel"')
+		// Logged out users get an empty payload here, which is an expected state and not an error.
+		if (!userData?.streamer_channel) {
+			info('KICK', 'NET', 'User is not logged in, skipping personal user data.')
+			return
+		}
 
 		const { id, user_id, slug } = userData.streamer_channel
 		if (!id) throw new Error('Invalid user data, missing property "id"')
@@ -620,11 +622,12 @@ export default class KickNetworkInterface implements NetworkInterface {
 			RESTFromMainService.get(`https://kick.com/api/v2/channels/${slug}/me`),
 			RESTFromMainService.get(`https://kick.com/api/v2/channels/${slug}`)
 		])
-		if (res1.status === 'rejected' || res2.status === 'rejected') {
+		// The /me request fails with 401 for logged out users, which must not block the user card.
+		if (res2.status === 'rejected') {
 			throw new Error('Failed to fetch user data')
 		}
 
-		const userMeInfo = res1.value
+		const userMeInfo = res1.status === 'fulfilled' ? res1.value : undefined
 		const userOwnChannelInfo = res2.value
 
 		// log('KICK', 'NET', 'User me info:', userMeInfo)
@@ -640,7 +643,7 @@ export default class KickNetworkInterface implements NetworkInterface {
 			createdAt: userOwnChannelInfo?.chatroom?.created_at
 				? new Date(userOwnChannelInfo?.chatroom?.created_at)
 				: null,
-			isFollowing: userMeInfo.is_following
+			isFollowing: !!userMeInfo?.is_following
 		}
 	}
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -402,7 +402,6 @@ class NipahClient {
 			}
 		}
 
-		if (!session.meData) throw new Error('Failed to load me user data.')
 		if (!session.channelData) throw new Error('Failed to load channel data.')
 
 		const channelData = session.channelData
@@ -549,7 +548,7 @@ class NipahClient {
 		rootContext.eventService.addEventListener(channelData, 'USER_BANNED', data => {
 			eventBus.publish('ntv.channel.chatroom.user.banned', data)
 
-			if (data.user.id === meData.userId) {
+			if (meData && data.user.id === meData.userId) {
 				log('CORE', 'MAIN', 'You have been banned from the channel..')
 
 				session.channelData.me.isBanned = {
@@ -576,7 +575,7 @@ class NipahClient {
 		rootContext.eventService.addEventListener(channelData, 'USER_UNBANNED', data => {
 			eventBus.publish('ntv.channel.chatroom.user.unbanned', data)
 
-			if (data.user.id === meData.userId) {
+			if (meData && data.user.id === meData.userId) {
 				if (unbanTimeoutHandle) clearTimeout(unbanTimeoutHandle)
 				log('CORE', 'MAIN', 'You have been unbanned from the channel..')
 


### PR DESCRIPTION
## Summary

NipahTV did not initialize on Kick when the user was not logged in, so the
extension stayed inactive and its user card never opened on public channels.

Kick returns an empty payload from `/api/v1/user` and `401 Unauthorized` from
`/channels/{channel}/me` for logged out users. Both were treated as fatal
errors, which aborted session creation and made `getUserInfo` reject.

This PR treats those responses as an expected logged out state.

Fixes #248

## Changes

- `src/Sites/Kick/KickNetworkInterface.ts`
  - `loadMeData` returns early and logs an info message when Kick provides no
    `streamer_channel`, instead of throwing.
  - `getUserInfo` only fails when the channel request itself fails, so the
    expected `401` from `/me` no longer blocks the user card.
  - `isFollowing` falls back to `false` when no personal data is available.
- `src/app.ts`
  - Dropped the `meData` requirement when creating a channel session.
  - Guarded the `USER_BANNED` and `USER_UNBANNED` handlers that dereference
    `meData`.
- `src/@types/global.d.ts`
  - `Session.meData` is now optional, matching the logged out case.
- `src/Extensions/SevenTV/index.ts`
  - Skips the personal 7TV cosmetics request when no platform user id exists.

No behavior was changed for logged in users, and no UI code was touched.

## Testing

- `npm run build-chrome`
- `npx tsc --noEmit` shows no new errors in the changed files
- Manual testing in a clean, logged out Chromium profile on `kick.com/xqc`:
  - the session initializes and emotes render (25 messages rendered, none left
    in the `--unrendered` state)
  - the NipahTV emote menu button is present in the chat footer
  - clicking a chat username opens the NipahTV user card with correct data
    (account creation and following dates), and Kick's native card stays hidden
  - no error toasts and no uncaught exceptions from these code paths

---
### Before  
<img width="649" height="977" alt="image" src="https://github.com/user-attachments/assets/58e7e197-c095-4d9e-910c-f41619ad9c6a" />  <br />

### After  
<img width="636" height="980" alt="image" src="https://github.com/user-attachments/assets/80ac81b3-e78c-49bc-aff6-dffdc7352342" />  
